### PR TITLE
fix/vercel-404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/",
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION

🔧 Fix: Vercel 404 Error on Page Refresh

Summary:
This PR addresses the issue where refreshing a page or directly accessing a route in production (Vercel deployment) resulted in a 404: NOT_FOUND error.

Fixes Applied:
	•	Added a custom vercel.json rewrite rule to redirect all routes to index.html, enabling proper client-side routing with React Router.
	•	Ensured vite.config.js is correctly set with base: "/" for consistent path resolution.


